### PR TITLE
Update Standard-JS version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "standard": "^8.3.0"
+    "standard": "^10.0.2"
   },
   "standard": {
     "parser": "babel-eslint"


### PR DESCRIPTION
No need to push a new release, it just updates the development dependency on Standard JS so we can run on the latest version.

Everything should run just fine!