### PR TITLE
Use the cached, revived options

### DIFF
--- a/lib/love-provider.js
+++ b/lib/love-provider.js
@@ -19,6 +19,6 @@ export default class LoveProvider {
       }
     }
 
-    return utils.mergeOptionsCached(await previousOptions, this.completions, cache)
+    return utils.mergeOptionsCached(await previousOptions, this.revived, cache)
   }
 }


### PR DESCRIPTION
This commit fixes a bug introduced in PR #10 where instead of using the cached `this.revived` options in `utils.mergeOptionsCached` it was passing `this.completions`.

This means that `utils.mergeOptionsCached` had to revive the options every single time (or maybe it was using un-revived options which may lead to unexpected erroneous behaviour)

This should fix it