### PR TITLE
Fix methods with no arguments

### DIFF
--- a/generator/json-generator.lua
+++ b/generator/json-generator.lua
@@ -77,12 +77,10 @@ end
 -- TODO handle functions with neither args nor return variables.
 local function createVariant( vdef, isMethod )
     local variant = {}
-    if vdef.description then
-        variant.description = vdef.description
-    end
-    if vdef.arguments or isMethod then
-        variant.args = createArguments( vdef.arguments, isMethod )
-    end
+
+    variant.description = vdef.description
+    variant.args = createArguments( vdef.arguments, isMethod )
+
     return variant
 end
 


### PR DESCRIPTION
Methods with no arguments should still have an arguments (`args`) table which only has `self` in it. Fixes #16

Renamed `includeDummy` to `isMethod` in the process

Note: The second commit is optional